### PR TITLE
Updates and support compiled policy evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,9 @@ _Note: this library has not been audited, thus its security has not been indepen
 
 For more information on Sigsum visit the [sigsum.org](https://sigsum.org) or the [development repository](https://git.glasklar.is/sigsum/core/sigsum-go).
 
-## Branded crypto types
+## Nominal crypto types
 
-To avoid accidental misuse of cryptographic types, `sigsum-ts` uses [branded types](https://egghead.io/blog/using-branded-types-in-typescript). This approach wraps primitive types like `Uint8Array` and `string` in nominal type markers, ensuring that a `Hash`, `Signature`, `KeyHash`, and `RawPublicKey` are not interchangeable, even if they share the same underlying structure. This eliminates a common class of bugs where buffers are passed to the wrong verification or hashing function due to implicit typing.
-
-For example:
-
-```ts
-export type Hash = Branded<Uint8Array, "Hash">;
-export type Signature = Branded<Uint8Array, "Signature">;
-export type KeyHash = Branded<Uint8Array, "KeyHash">;
-export type Base64KeyHash = Branded<string, "Base64KeyHash">;
-export type RawPublicKey = Branded<Uint8Array, "RawPublicKey">;
-export type PublicKey = Branded<CryptoKey, "PublicKey">;
-```
-
-As a result, explicit casts or carefully constructed wrappers are required to use these types, which provides a helpful layer of safety when handling cryptographic material.
+To prevent accidental misuse of cryptographic material, `sigsum-ts` defines explicit nominal wrapper classes for each crypto type. Although many of them internally wrap a `Uint8Array` or a `string`, they are not interchangeable, and TypeScript will refuse to pass a `Hash` where a `Signature` is expected.
 
 ## Usage
 
@@ -53,42 +40,14 @@ const isValid = await verifyMessage(
 );
 ```
 
-## Tests
+## Experimental policy compilation & evaluation
 
-```bash
-$ npm run test
+This project includes a policy compiler and bytecode-based evaluator adapted from the [Sigsum C](https://git.glasklar.is/nisse/sigsum-c) reference implementation. The goal is to make policy verification compact and efficient, suitable for constrained environments with limited memory and binary size requirements (e.g., embedded devices).
 
-> sigsum-ts@0.1 test
-> vitest run --coverage
+Both the compiled format and the evaluation logic are experimental and unstable as they may change without notice as the Sigsum ecosystem evolves.
 
+References:
 
- RUN  v3.2.0 /Users/g/sigsum-ts
-      Coverage enabled with v8
-
- ✓ src/tests/econding.test.ts (8 tests) 3ms
- ✓ src/tests/proof.test.ts (18 tests) 8ms
- ✓ src/tests/crypto.test.ts (23 tests) 25ms
- ✓ src/tests/config.test.ts (17 tests) 36ms
- ✓ src/tests/verify.test.ts (12 tests) 46ms
-
- Test Files  5 passed (5)
-      Tests  78 passed (78)
-   Start at  19:39:46
-   Duration  472ms (transform 163ms, setup 0ms, collect 300ms, tests 118ms, environment 1ms, prepare 392ms)
-
- % Coverage report from v8
---------------|---------|----------|---------|---------|-------------------
-File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------|---------|----------|---------|---------|-------------------
-All files     |     100 |      100 |     100 |     100 |
- config.ts    |     100 |      100 |     100 |     100 |
- constants.ts |     100 |      100 |     100 |     100 |
- crypto.ts    |     100 |      100 |     100 |     100 |
- encoding.ts  |     100 |      100 |     100 |     100 |
- format.ts    |     100 |      100 |     100 |     100 |
- policy.ts    |     100 |      100 |     100 |     100 |
- proof.ts     |     100 |      100 |     100 |     100 |
- types.ts     |     100 |      100 |     100 |     100 |
- verify.ts    |     100 |      100 |     100 |     100 |
---------------|---------|----------|---------|---------|-------------------
-```
+- [Sigsum and Tillitis TKey – Exploring transparency apps](https://www.glasklarteknik.se/post/exploring-transparency-apps-tkey/)
+- [sigsum-compile-policy.c](https://git.glasklar.is/nisse/sigsum-c/-/blob/main/tools/sigsum-compile-policy.c)
+- [verify.c](https://git.glasklar.is/nisse/sigsum-c/-/blob/main/lib/verify.c)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,15 @@
       "name": "sigsum",
       "version": "0.2.0",
       "license": "MIT",
+      "dependencies": {
+        "yargs": "^18.0.0"
+      },
       "devDependencies": {
-        "@vitest/coverage-v8": "^4.0.6",
+        "@vitest/coverage-v8": "^4.0.5",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.46.3",
-        "vitest": "^4.0.6"
+        "typescript-eslint": "^8.46.2",
+        "vitest": "^4.0.5"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -27,9 +30,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -37,13 +40,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.4.tgz",
-      "integrity": "sha512-BRmLHGwpUqLFR2jzx9orBuX/ABDkj2jLKOXrHDTN2aOKL+jFDDKaRNo9nyYsIl9h/UE/7lMKdDjKQQyxKKDZ7g==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.28.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -53,14 +56,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -77,9 +80,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.11.tgz",
-      "integrity": "sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -94,9 +97,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.11.tgz",
-      "integrity": "sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -111,9 +114,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.11.tgz",
-      "integrity": "sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -128,9 +131,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.11.tgz",
-      "integrity": "sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -145,9 +148,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.11.tgz",
-      "integrity": "sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -162,9 +165,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.11.tgz",
-      "integrity": "sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -179,9 +182,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.11.tgz",
-      "integrity": "sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -196,9 +199,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.11.tgz",
-      "integrity": "sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -213,9 +216,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.11.tgz",
-      "integrity": "sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -230,9 +233,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.11.tgz",
-      "integrity": "sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -247,9 +250,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.11.tgz",
-      "integrity": "sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -264,9 +267,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.11.tgz",
-      "integrity": "sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -281,9 +284,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.11.tgz",
-      "integrity": "sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -298,9 +301,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.11.tgz",
-      "integrity": "sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -315,9 +318,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.11.tgz",
-      "integrity": "sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -332,9 +335,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.11.tgz",
-      "integrity": "sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -349,9 +352,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.11.tgz",
-      "integrity": "sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -366,9 +369,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.11.tgz",
-      "integrity": "sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
@@ -383,9 +386,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.11.tgz",
-      "integrity": "sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -400,9 +403,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.11.tgz",
-      "integrity": "sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
@@ -417,9 +420,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.11.tgz",
-      "integrity": "sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -434,9 +437,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.11.tgz",
-      "integrity": "sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
       ],
@@ -451,9 +454,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.11.tgz",
-      "integrity": "sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -468,9 +471,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.11.tgz",
-      "integrity": "sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -485,9 +488,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.11.tgz",
-      "integrity": "sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -502,9 +505,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.11.tgz",
-      "integrity": "sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -519,9 +522,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -551,9 +554,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -561,14 +564,14 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -577,20 +580,23 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
-      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -627,9 +633,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
-      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
+      "version": "9.39.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
+      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -641,9 +647,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -652,29 +658,15 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
-      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -692,33 +684,18 @@
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -818,9 +795,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
-      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.2.tgz",
+      "integrity": "sha512-yDPzwsgiFO26RJA4nZo8I+xqzh7sJTZIWQOxn+/XOdPE31lAvLIYCKqjV+lNH/vxE2L2iH3plKxDCRK6i+CwhA==",
       "cpu": [
         "arm"
       ],
@@ -832,9 +809,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
-      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.2.tgz",
+      "integrity": "sha512-k8FontTxIE7b0/OGKeSN5B6j25EuppBcWM33Z19JoVT7UTXFSo3D9CdU39wGTeb29NO3XxpMNauh09B+Ibw+9g==",
       "cpu": [
         "arm64"
       ],
@@ -846,9 +823,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
-      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.2.tgz",
+      "integrity": "sha512-A6s4gJpomNBtJ2yioj8bflM2oogDwzUiMl2yNJ2v9E7++sHrSrsQ29fOfn5DM/iCzpWcebNYEdXpaK4tr2RhfQ==",
       "cpu": [
         "arm64"
       ],
@@ -860,9 +837,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
-      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.2.tgz",
+      "integrity": "sha512-e6XqVmXlHrBlG56obu9gDRPW3O3hLxpwHpLsBJvuI8qqnsrtSZ9ERoWUXtPOkY8c78WghyPHZdmPhHLWNdAGEw==",
       "cpu": [
         "x64"
       ],
@@ -874,9 +851,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
-      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.2.tgz",
+      "integrity": "sha512-v0E9lJW8VsrwPux5Qe5CwmH/CF/2mQs6xU1MF3nmUxmZUCHazCjLgYvToOk+YuuUqLQBio1qkkREhxhc656ViA==",
       "cpu": [
         "arm64"
       ],
@@ -888,9 +865,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
-      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.2.tgz",
+      "integrity": "sha512-ClAmAPx3ZCHtp6ysl4XEhWU69GUB1D+s7G9YjHGhIGCSrsg00nEGRRZHmINYxkdoJehde8VIsDC5t9C0gb6yqA==",
       "cpu": [
         "x64"
       ],
@@ -902,9 +879,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
-      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.2.tgz",
+      "integrity": "sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==",
       "cpu": [
         "arm"
       ],
@@ -916,9 +893,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
-      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.2.tgz",
+      "integrity": "sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==",
       "cpu": [
         "arm"
       ],
@@ -930,9 +907,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
-      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.2.tgz",
+      "integrity": "sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==",
       "cpu": [
         "arm64"
       ],
@@ -944,9 +921,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
-      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.2.tgz",
+      "integrity": "sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==",
       "cpu": [
         "arm64"
       ],
@@ -958,9 +935,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
-      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.2.tgz",
+      "integrity": "sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==",
       "cpu": [
         "loong64"
       ],
@@ -972,9 +949,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
-      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.2.tgz",
+      "integrity": "sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==",
       "cpu": [
         "ppc64"
       ],
@@ -986,9 +963,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
-      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.2.tgz",
+      "integrity": "sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==",
       "cpu": [
         "riscv64"
       ],
@@ -1000,9 +977,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
-      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.2.tgz",
+      "integrity": "sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1014,9 +991,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
-      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.2.tgz",
+      "integrity": "sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==",
       "cpu": [
         "s390x"
       ],
@@ -1028,9 +1005,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
-      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.2.tgz",
+      "integrity": "sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==",
       "cpu": [
         "x64"
       ],
@@ -1042,9 +1019,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
-      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.2.tgz",
+      "integrity": "sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==",
       "cpu": [
         "x64"
       ],
@@ -1056,9 +1033,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
-      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.2.tgz",
+      "integrity": "sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==",
       "cpu": [
         "arm64"
       ],
@@ -1070,9 +1047,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
-      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.2.tgz",
+      "integrity": "sha512-IlbHFYc/pQCgew/d5fslcy1KEaYVCJ44G8pajugd8VoOEI8ODhtb/j8XMhLpwHCMB3yk2J07ctup10gpw2nyMA==",
       "cpu": [
         "arm64"
       ],
@@ -1084,9 +1061,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
-      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.2.tgz",
+      "integrity": "sha512-lNlPEGgdUfSzdCWU176ku/dQRnA7W+Gp8d+cWv73jYrb8uT7HTVVxq62DUYxjbaByuf1Yk0RIIAbDzp+CnOTFg==",
       "cpu": [
         "ia32"
       ],
@@ -1098,9 +1075,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
-      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.2.tgz",
+      "integrity": "sha512-S6YojNVrHybQis2lYov1sd+uj7K0Q05NxHcGktuMMdIQ2VixGwAfbJ23NnlvvVV1bdpR2m5MsNBViHJKcA4ADw==",
       "cpu": [
         "x64"
       ],
@@ -1112,9 +1089,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
-      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.2.tgz",
+      "integrity": "sha512-k+/Rkcyx//P6fetPoLMb8pBeqJBNGx81uuf7iljX9++yNBVRDQgD04L+SVXmXmh5ZP4/WOp4mWF0kmi06PW2tA==",
       "cpu": [
         "x64"
       ],
@@ -1424,30 +1401,30 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.6.tgz",
-      "integrity": "sha512-cv6pFXj9/Otk7q1Ocoj8k3BUVVwnFr3jqcqpwYrU5LkKClU9DpaMEdX+zptx/RyIJS+/VpoxMWmfISXchmVDPQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.8.tgz",
+      "integrity": "sha512-wQgmtW6FtPNn4lWUXi8ZSYLpOIb92j3QCujxX3sQ81NTfQ/ORnE0HtK7Kqf2+7J9jeveMGyGyc4NWc5qy3rC4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.6",
-        "ast-v8-to-istanbul": "^0.3.5",
+        "@vitest/utils": "4.0.8",
+        "ast-v8-to-istanbul": "^0.3.8",
         "debug": "^4.4.3",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-lib-source-maps": "^5.0.6",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.3.5",
-        "std-env": "^3.9.0",
+        "magicast": "^0.5.1",
+        "std-env": "^3.10.0",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.6",
-        "vitest": "4.0.6"
+        "@vitest/browser": "4.0.8",
+        "vitest": "4.0.8"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1456,17 +1433,17 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.6.tgz",
-      "integrity": "sha512-5j8UUlBVhOjhj4lR2Nt9sEV8b4WtbcYh8vnfhTNA2Kn5+smtevzjNq+xlBuVhnFGXiyPPNzGrOVvmyHWkS5QGg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.8.tgz",
+      "integrity": "sha512-Rv0eabdP/xjAHQGr8cjBm+NnLHNoL268lMDK85w2aAGLFoVKLd8QGnVon5lLtkXQCoYaNL0wg04EGnyKkkKhPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.6",
-        "@vitest/utils": "4.0.6",
-        "chai": "^6.0.1",
+        "@vitest/spy": "4.0.8",
+        "@vitest/utils": "4.0.8",
+        "chai": "^6.2.0",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -1474,15 +1451,15 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.6.tgz",
-      "integrity": "sha512-3COEIew5HqdzBFEYN9+u0dT3i/NCwppLnO1HkjGfAP1Vs3vti1Hxm/MvcbC4DAn3Szo1M7M3otiAaT83jvqIjA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.8.tgz",
+      "integrity": "sha512-9FRM3MZCedXH3+pIh+ME5Up2NBBHDq0wqwhOKkN4VnvCiKbVxddqH9mSGPZeawjd12pCOGnl+lo/ZGHt0/dQSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.6",
+        "@vitest/spy": "4.0.8",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.19"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1501,9 +1478,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.6.tgz",
-      "integrity": "sha512-4vptgNkLIA1W1Nn5X4x8rLJBzPiJwnPc+awKtfBE5hNMVsoAl/JCCPPzNrbf+L4NKgklsis5Yp2gYa+XAS442g==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.8.tgz",
+      "integrity": "sha512-qRrjdRkINi9DaZHAimV+8ia9Gq6LeGz2CgIEmMLz3sBDYV53EsnLZbJMR1q84z1HZCMsf7s0orDgZn7ScXsZKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1514,13 +1491,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.6.tgz",
-      "integrity": "sha512-trPk5qpd7Jj+AiLZbV/e+KiiaGXZ8ECsRxtnPnCrJr9OW2mLB72Cb824IXgxVz/mVU3Aj4VebY+tDTPn++j1Og==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.8.tgz",
+      "integrity": "sha512-mdY8Sf1gsM8hKJUQfiPT3pn1n8RF4QBcJYFslgWh41JTfrK1cbqY8whpGCFzBl45LN028g0njLCYm0d7XxSaQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.6",
+        "@vitest/utils": "4.0.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1528,14 +1505,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.6.tgz",
-      "integrity": "sha512-PaYLt7n2YzuvxhulDDu6c9EosiRuIE+FI2ECKs6yvHyhoga+2TBWI8dwBjs+IeuQaMtZTfioa9tj3uZb7nev1g==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.8.tgz",
+      "integrity": "sha512-Nar9OTU03KGiubrIOFhcfHg8FYaRaNT+bh5VUlNz8stFhCZPNrJvmZkhsr1jtaYvuefYFwK2Hwrq026u4uPWCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.6",
-        "magic-string": "^0.30.19",
+        "@vitest/pretty-format": "4.0.8",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1543,9 +1520,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.6.tgz",
-      "integrity": "sha512-g9jTUYPV1LtRPRCQfhbMintW7BTQz1n6WXYQYRQ25qkyffA4bjVXjkROokZnv7t07OqfaFKw1lPzqKGk1hmNuQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.8.tgz",
+      "integrity": "sha512-nvGVqUunyCgZH7kmo+Ord4WgZ7lN0sOULYXUOYuHr55dvg9YvMz3izfB189Pgp28w0vWFbEEfNc/c3VTrqrXeA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1553,13 +1530,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-bG43VS3iYKrMIZXBo+y8Pti0O7uNju3KvNn6DrQWhQQKcLavMB+0NZfO1/QBAEbq0MaQ3QjNsnnXlGQvsh0Z6A==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.8.tgz",
+      "integrity": "sha512-pdk2phO5NDvEFfUTxcTP8RFYjVj/kfLSPIN5ebP2Mu9kcIMeAQTbknqcFEyBcC4z2pJlJI9aS5UQjcYfhmKAow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.6",
+        "@vitest/pretty-format": "4.0.8",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -1567,9 +1544,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1609,6 +1586,35 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1628,9 +1634,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.7.tgz",
-      "integrity": "sha512-kr1Hy6YRZBkGQSb6puP+D6FQ59Cx4m0siYhAxygMCAgadiWQ6oxAxQXHOMvJx67SJ63jRoVIIg5eXzUbbct1ww==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.8.tgz",
+      "integrity": "sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1710,21 +1716,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">=20"
       }
     },
     "node_modules/color-convert": {
@@ -1799,6 +1802,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -1807,9 +1816,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.11",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.11.tgz",
-      "integrity": "sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1820,32 +1829,41 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.11",
-        "@esbuild/android-arm": "0.25.11",
-        "@esbuild/android-arm64": "0.25.11",
-        "@esbuild/android-x64": "0.25.11",
-        "@esbuild/darwin-arm64": "0.25.11",
-        "@esbuild/darwin-x64": "0.25.11",
-        "@esbuild/freebsd-arm64": "0.25.11",
-        "@esbuild/freebsd-x64": "0.25.11",
-        "@esbuild/linux-arm": "0.25.11",
-        "@esbuild/linux-arm64": "0.25.11",
-        "@esbuild/linux-ia32": "0.25.11",
-        "@esbuild/linux-loong64": "0.25.11",
-        "@esbuild/linux-mips64el": "0.25.11",
-        "@esbuild/linux-ppc64": "0.25.11",
-        "@esbuild/linux-riscv64": "0.25.11",
-        "@esbuild/linux-s390x": "0.25.11",
-        "@esbuild/linux-x64": "0.25.11",
-        "@esbuild/netbsd-arm64": "0.25.11",
-        "@esbuild/netbsd-x64": "0.25.11",
-        "@esbuild/openbsd-arm64": "0.25.11",
-        "@esbuild/openbsd-x64": "0.25.11",
-        "@esbuild/openharmony-arm64": "0.25.11",
-        "@esbuild/sunos-x64": "0.25.11",
-        "@esbuild/win32-arm64": "0.25.11",
-        "@esbuild/win32-ia32": "0.25.11",
-        "@esbuild/win32-x64": "0.25.11"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1863,34 +1881,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
-      "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
+      "version": "9.39.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
+      "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.14.0",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.27.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/js": "9.39.1",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1935,9 +1952,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -1966,16 +1983,16 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2199,6 +2216,27 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob-parent": {
@@ -2495,15 +2533,15 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {
@@ -2612,24 +2650,7 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate/node_modules/p-limit": {
+    "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -2646,13 +2667,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -2818,9 +2842,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
-      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "version": "4.53.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.2.tgz",
+      "integrity": "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2834,28 +2858,28 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.52.5",
-        "@rollup/rollup-android-arm64": "4.52.5",
-        "@rollup/rollup-darwin-arm64": "4.52.5",
-        "@rollup/rollup-darwin-x64": "4.52.5",
-        "@rollup/rollup-freebsd-arm64": "4.52.5",
-        "@rollup/rollup-freebsd-x64": "4.52.5",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
-        "@rollup/rollup-linux-arm64-musl": "4.52.5",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
-        "@rollup/rollup-linux-x64-gnu": "4.52.5",
-        "@rollup/rollup-linux-x64-musl": "4.52.5",
-        "@rollup/rollup-openharmony-arm64": "4.52.5",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
-        "@rollup/rollup-win32-x64-gnu": "4.52.5",
-        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "@rollup/rollup-android-arm-eabi": "4.53.2",
+        "@rollup/rollup-android-arm64": "4.53.2",
+        "@rollup/rollup-darwin-arm64": "4.53.2",
+        "@rollup/rollup-darwin-x64": "4.53.2",
+        "@rollup/rollup-freebsd-arm64": "4.53.2",
+        "@rollup/rollup-freebsd-x64": "4.53.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.53.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.53.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.53.2",
+        "@rollup/rollup-linux-arm64-musl": "4.53.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.53.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.53.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.53.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.53.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.53.2",
+        "@rollup/rollup-linux-x64-gnu": "4.53.2",
+        "@rollup/rollup-linux-x64-musl": "4.53.2",
+        "@rollup/rollup-openharmony-arm64": "4.53.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.53.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.53.2",
+        "@rollup/rollup-win32-x64-gnu": "4.53.2",
+        "@rollup/rollup-win32-x64-msvc": "4.53.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -2884,9 +2908,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2951,6 +2975,38 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3141,9 +3197,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
-      "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
+      "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3247,26 +3303,26 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.6.tgz",
-      "integrity": "sha512-gR7INfiVRwnEOkCk47faros/9McCZMp5LM+OMNWGLaDBSvJxIzwjgNFufkuePBNaesGRnLmNfW+ddbUJRZn0nQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.8.tgz",
+      "integrity": "sha512-urzu3NCEV0Qa0Y2PwvBtRgmNtxhj5t5ULw7cuKhIHh3OrkKTLlut0lnBOv9qe5OvbkMH2g38G7KPDCTpIytBVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.6",
-        "@vitest/mocker": "4.0.6",
-        "@vitest/pretty-format": "4.0.6",
-        "@vitest/runner": "4.0.6",
-        "@vitest/snapshot": "4.0.6",
-        "@vitest/spy": "4.0.6",
-        "@vitest/utils": "4.0.6",
+        "@vitest/expect": "4.0.8",
+        "@vitest/mocker": "4.0.8",
+        "@vitest/pretty-format": "4.0.8",
+        "@vitest/runner": "4.0.8",
+        "@vitest/snapshot": "4.0.8",
+        "@vitest/spy": "4.0.8",
+        "@vitest/utils": "4.0.8",
         "debug": "^4.4.3",
         "es-module-lexer": "^1.7.0",
         "expect-type": "^1.2.2",
-        "magic-string": "^0.30.19",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.9.0",
+        "std-env": "^3.10.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
         "tinyglobby": "^0.2.15",
@@ -3287,10 +3343,10 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.6",
-        "@vitest/browser-preview": "4.0.6",
-        "@vitest/browser-webdriverio": "4.0.6",
-        "@vitest/ui": "4.0.6",
+        "@vitest/browser-playwright": "4.0.8",
+        "@vitest/browser-preview": "4.0.8",
+        "@vitest/browser-webdriverio": "4.0.8",
+        "@vitest/ui": "4.0.8",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -3380,6 +3436,84 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
-    "lint": "npx eslint . --fix && npx prettier --write ."
+    "lint": "npx eslint . --fix && npx prettier --write .",
+    "clean": "rm -rf dist/*"
   },
   "keywords": [
     "sigsum",
@@ -23,10 +24,13 @@
   "repository": "github:freedomofpress/sigsum-ts",
   "bugs": "https://github.com/freedomofpress/sigsum-ts/issues",
   "devDependencies": {
-    "typescript": "^5.9.3",
-    "vitest": "^4.0.6",
-    "@vitest/coverage-v8": "^4.0.6",
+    "@vitest/coverage-v8": "^4.0.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "typescript-eslint": "^8.46.3"
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.46.2",
+    "vitest": "^4.0.5"
+  },
+  "dependencies": {
+    "yargs": "^18.0.0"
   }
 }

--- a/src/compiledPolicy.ts
+++ b/src/compiledPolicy.ts
@@ -1,0 +1,173 @@
+import { hashKey, importKey } from "./crypto";
+import { Uint8ArrayToBase64 } from "./encoding";
+import { Base64KeyHash, KeyHash, PublicKey, RawPublicKey } from "./types";
+
+const DEFAULT_RAW_PUBKEY_LEN = 32;
+
+export interface CompiledPolicy {
+  version: number;
+  logsRaw: Uint8Array[]; // raw public keys
+  witnessesRaw: Uint8Array[]; // raw public keys
+  quorum: Uint8Array; // bytecode
+}
+
+export function parseCompiledPolicy(
+  buf: Uint8Array,
+  rawPubLen = DEFAULT_RAW_PUBKEY_LEN,
+): CompiledPolicy {
+  if (buf.length < 4) throw new Error("compiled policy too short");
+  const version = buf[0];
+  const nLogs = buf[1];
+  const nWitnesses = buf[2];
+  const quorumLen = buf[3];
+
+  let off = 4;
+
+  const expect = (n: number) => {
+    if (off + n > buf.length) throw new Error("compiled policy truncated");
+  };
+
+  // logs
+  const logsRaw: Uint8Array[] = [];
+  expect(nLogs * rawPubLen);
+  for (let i = 0; i < nLogs; i++) {
+    logsRaw.push(buf.slice(off, off + rawPubLen));
+    off += rawPubLen;
+  }
+
+  // witnesses
+  const witnessesRaw: Uint8Array[] = [];
+  expect(nWitnesses * rawPubLen);
+  for (let i = 0; i < nWitnesses; i++) {
+    witnessesRaw.push(buf.slice(off, off + rawPubLen));
+    off += rawPubLen;
+  }
+
+  // quorum bytecode
+  expect(quorumLen);
+  const quorum = buf.slice(off, off + quorumLen);
+
+  return { version, logsRaw, witnessesRaw, quorum };
+}
+
+type HashedKey = {
+  pub: PublicKey;
+  raw: RawPublicKey;
+  hash: KeyHash;
+  b64: Base64KeyHash;
+};
+
+// Build hashed, sorted lists that mirror the compiler order (compiler sorted by key-hash).
+// We recompute key-hash locally and sort—safe even if the compiler was strict about order.
+export async function importAndHashAll(
+  raws: Uint8Array[],
+): Promise<HashedKey[]> {
+  const out: HashedKey[] = [];
+  for (const rawBytes of raws) {
+    const raw = new RawPublicKey(rawBytes);
+    const pub = await importKey(raw);
+    const hash = await hashKey(pub);
+    const b64 = new Base64KeyHash(Uint8ArrayToBase64(hash.bytes));
+    out.push({
+      pub,
+      raw,
+      hash,
+      b64,
+    });
+  }
+  // lexicographic sort on hash bytes
+  out.sort((a, b) => {
+    const A = a.hash as unknown as Uint8Array;
+    const B = b.hash as unknown as Uint8Array;
+    for (let i = 0; i < A.length && i < B.length; i++) {
+      if (A[i] !== B[i]) return A[i] - B[i];
+    }
+    return A.length - B.length;
+  });
+  return out;
+}
+
+// Evaluate quorum bytecode like the C
+// Byte layout:
+//  - top 2 bits are the opcode "class"
+//    00: special (only 0x01 = ADD is valid here)
+//    01: witness reference (push witnesses[id])
+//    10: threshold (>= K) (fold top stack entry to 0/1)
+//    11: prefix continuation for multi-byte ids/K
+//
+// Stack is an array of unsigned bytes.
+export function evalQuorumBytecode(
+  quorum: Uint8Array,
+  nwitnesses: number,
+  found: Uint8Array,
+  scratch?: Uint8Array,
+): boolean {
+  const stack = scratch ?? new Uint8Array(Math.max(1, quorum.length));
+  let sp = 0;
+  let prefix = 0 >>> 0;
+
+  const push = (v: number) => {
+    stack[sp++] = v & 0xff;
+  };
+
+  const pop1 = (): number => {
+    if (sp === 0) {
+      throw new Error("stack underflow");
+    }
+
+    sp--;
+    return stack[sp];
+  };
+
+  for (let i = 0; i < quorum.length; i++) {
+    const instr = quorum[i];
+    const cls = instr >>> 6;
+    const low = instr & 0x3f;
+
+    switch (cls) {
+      case 0: {
+        // special
+        prefix = 0;
+        if (instr === 0x01) {
+          // ADD
+          if (sp < 2) return false;
+          const a = pop1();
+          const b = pop1();
+          const s = (a + b) & 0xff;
+          // emulate overflow check like C (optional in JS, but we keep to spec spirit)
+          if (s < a || s < b) return false;
+          push(s);
+        } else {
+          return false;
+        }
+        break;
+      }
+
+      case 1: {
+        // witness reference X?
+        const id = ((prefix << 6) | low) >>> 0;
+        prefix = 0;
+        if (id >= nwitnesses) return false;
+        push(found[id]);
+        break;
+      }
+
+      case 2: {
+        // >= K
+        if (sp < 1) return false;
+        const k = ((prefix << 6) | low) >>> 0;
+        prefix = 0;
+        const top = pop1();
+        push(top >= k ? 1 : 0);
+        break;
+      }
+
+      case 3: {
+        prefix = (prefix << 6) | low;
+        continue;
+      }
+    }
+  }
+
+  return sp === 1 && stack[0] === 1;
+}

--- a/src/format.ts
+++ b/src/format.ts
@@ -6,8 +6,8 @@ export function formatCheckpoint(
   treeHead: TreeHead,
   logKeyHash: KeyHash,
 ): string {
-  const origin = CheckpointNamePrefix + Uint8ArrayToHex(logKeyHash);
-  const rootHash = Uint8ArrayToBase64(treeHead.RootHash);
+  const origin = CheckpointNamePrefix + Uint8ArrayToHex(logKeyHash.bytes);
+  const rootHash = Uint8ArrayToBase64(treeHead.RootHash.bytes);
   const checkpointStr = `${origin}\n${treeHead.Size}\n${rootHash}\n`;
   return checkpointStr;
 }

--- a/src/tests/crypto.test.ts
+++ b/src/tests/crypto.test.ts
@@ -35,73 +35,95 @@ cosignature=e923764535cac36836d1af682a2a3e5352e2636ec29c1d34c00160e1f4946d31 174
 leaf_index=1
 `;
 
-const VALID_PUBLIC_KEY = new Uint8Array([
-  235, 19, 108, 27, 6, 73, 64, 86, 192, 69, 29, 238, 123, 65, 67, 224, 101, 29,
-  252, 40, 19, 100, 69, 16, 20, 107, 207, 165, 169, 155, 37, 250,
-]) as RawPublicKey;
+const VALID_PUBLIC_KEY = new RawPublicKey(
+  new Uint8Array([
+    235, 19, 108, 27, 6, 73, 64, 86, 192, 69, 29, 238, 123, 65, 67, 224, 101,
+    29, 252, 40, 19, 100, 69, 16, 20, 107, 207, 165, 169, 155, 37, 250,
+  ]),
+);
 
-const VALID_SIGNATURE = new Uint8Array([
-  140, 73, 191, 148, 174, 113, 109, 220, 188, 161, 249, 35, 177, 149, 245, 65,
-  158, 51, 120, 251, 158, 34, 237, 205, 237, 88, 184, 141, 20, 128, 74, 71, 0,
-  60, 226, 131, 180, 173, 121, 45, 248, 102, 92, 139, 157, 177, 87, 37, 78, 237,
-  89, 63, 73, 23, 11, 132, 206, 122, 111, 0, 200, 140, 217, 4,
-]) as Signature;
+const VALID_SIGNATURE = new Signature(
+  new Uint8Array([
+    140, 73, 191, 148, 174, 113, 109, 220, 188, 161, 249, 35, 177, 149, 245, 65,
+    158, 51, 120, 251, 158, 34, 237, 205, 237, 88, 184, 141, 20, 128, 74, 71, 0,
+    60, 226, 131, 180, 173, 121, 45, 248, 102, 92, 139, 157, 177, 87, 37, 78,
+    237, 89, 63, 73, 23, 11, 132, 206, 122, 111, 0, 200, 140, 217, 4,
+  ]),
+);
 
 const VALID_MESSAGE = new TextEncoder().encode("hello world");
 const INVALID_MESSAGE = new TextEncoder().encode("tampered message");
 const EXPECTED_BASE64_HASH = "fY20VJz2TPDYe09gUTGwfN6wiDFdSS9+O+5frwVd36c=";
 
-const LOG_PUBKEY = new Uint8Array([
-  0x46, 0x44, 0xaf, 0x2a, 0xbd, 0x40, 0xf4, 0x89, 0x5a, 0x00, 0x3b, 0xca, 0x35,
-  0x0f, 0x9d, 0x59, 0x12, 0xab, 0x30, 0x1a, 0x49, 0xc7, 0x7f, 0x13, 0xe5, 0xb6,
-  0xd9, 0x05, 0xc2, 0x0a, 0x5f, 0xe6,
-]) as RawPublicKey;
+const LOG_PUBKEY = new RawPublicKey(
+  new Uint8Array([
+    0x46, 0x44, 0xaf, 0x2a, 0xbd, 0x40, 0xf4, 0x89, 0x5a, 0x00, 0x3b, 0xca,
+    0x35, 0x0f, 0x9d, 0x59, 0x12, 0xab, 0x30, 0x1a, 0x49, 0xc7, 0x7f, 0x13,
+    0xe5, 0xb6, 0xd9, 0x05, 0xc2, 0x0a, 0x5f, 0xe6,
+  ]),
+);
 
-const TREEHEAD_ROOT_HASH = new Uint8Array([
-  0x22, 0x59, 0x6c, 0x88, 0x2d, 0xcd, 0xfb, 0xfa, 0xba, 0x69, 0x3c, 0xb6, 0x9b,
-  0x22, 0x5c, 0x81, 0xa8, 0xa9, 0x80, 0xe8, 0x4b, 0x3a, 0xd5, 0xfc, 0x1f, 0xcd,
-  0x6a, 0x25, 0x6e, 0xbd, 0xc2, 0x35,
-]) as Hash;
+const TREEHEAD_ROOT_HASH = new Hash(
+  new Uint8Array([
+    0x22, 0x59, 0x6c, 0x88, 0x2d, 0xcd, 0xfb, 0xfa, 0xba, 0x69, 0x3c, 0xb6,
+    0x9b, 0x22, 0x5c, 0x81, 0xa8, 0xa9, 0x80, 0xe8, 0x4b, 0x3a, 0xd5, 0xfc,
+    0x1f, 0xcd, 0x6a, 0x25, 0x6e, 0xbd, 0xc2, 0x35,
+  ]),
+);
 
-const TREEHEAD_SIGNATURE = new Uint8Array([
-  0x3a, 0xec, 0xf6, 0x43, 0xc4, 0x2d, 0x15, 0x86, 0x30, 0x00, 0x57, 0x66, 0x68,
-  0x98, 0x01, 0x07, 0xa0, 0x56, 0x98, 0x47, 0xf1, 0xb3, 0xf4, 0x3d, 0xf7, 0x0d,
-  0xcb, 0xf0, 0x70, 0x5b, 0xb5, 0x80, 0xda, 0xf6, 0xfa, 0x64, 0xc5, 0x86, 0xf4,
-  0xef, 0x78, 0x0a, 0x1b, 0x02, 0x08, 0x50, 0x30, 0xba, 0xb9, 0x3c, 0x84, 0x51,
-  0x36, 0xed, 0x1f, 0x9c, 0x78, 0xec, 0x96, 0x13, 0x93, 0xdf, 0xc1, 0x00,
-]) as Signature;
+const TREEHEAD_SIGNATURE = new Signature(
+  new Uint8Array([
+    0x3a, 0xec, 0xf6, 0x43, 0xc4, 0x2d, 0x15, 0x86, 0x30, 0x00, 0x57, 0x66,
+    0x68, 0x98, 0x01, 0x07, 0xa0, 0x56, 0x98, 0x47, 0xf1, 0xb3, 0xf4, 0x3d,
+    0xf7, 0x0d, 0xcb, 0xf0, 0x70, 0x5b, 0xb5, 0x80, 0xda, 0xf6, 0xfa, 0x64,
+    0xc5, 0x86, 0xf4, 0xef, 0x78, 0x0a, 0x1b, 0x02, 0x08, 0x50, 0x30, 0xba,
+    0xb9, 0x3c, 0x84, 0x51, 0x36, 0xed, 0x1f, 0x9c, 0x78, 0xec, 0x96, 0x13,
+    0x93, 0xdf, 0xc1, 0x00,
+  ]),
+);
 
-export const WITNESS_PUBKEY = new Uint8Array([
-  0x1c, 0x25, 0xf8, 0xa4, 0x4c, 0x63, 0x54, 0x57, 0xe2, 0xe3, 0x91, 0xd1, 0xef,
-  0xbc, 0xa7, 0xd4, 0xc2, 0x95, 0x1a, 0x0a, 0xef, 0x06, 0x22, 0x5a, 0x88, 0x1e,
-  0x46, 0xb9, 0x89, 0x62, 0xac, 0x6c,
-]) as RawPublicKey;
+export const WITNESS_PUBKEY = new RawPublicKey(
+  new Uint8Array([
+    0x1c, 0x25, 0xf8, 0xa4, 0x4c, 0x63, 0x54, 0x57, 0xe2, 0xe3, 0x91, 0xd1,
+    0xef, 0xbc, 0xa7, 0xd4, 0xc2, 0x95, 0x1a, 0x0a, 0xef, 0x06, 0x22, 0x5a,
+    0x88, 0x1e, 0x46, 0xb9, 0x89, 0x62, 0xac, 0x6c,
+  ]),
+);
 
-export const WITNESS_KEYHASH = new Uint8Array([
-  0x1c, 0x99, 0x72, 0x61, 0xf1, 0x6e, 0x6e, 0x81, 0xd1, 0x3f, 0x42, 0x09, 0x00,
-  0xa2, 0x54, 0x2a, 0x4b, 0x6a, 0x04, 0x9c, 0x2d, 0x99, 0x63, 0x24, 0xee, 0x5d,
-  0x82, 0xa9, 0x0c, 0xa3, 0x36, 0x0c,
-]) as KeyHash;
+export const WITNESS_KEYHASH = new KeyHash(
+  new Uint8Array([
+    0x1c, 0x99, 0x72, 0x61, 0xf1, 0x6e, 0x6e, 0x81, 0xd1, 0x3f, 0x42, 0x09,
+    0x00, 0xa2, 0x54, 0x2a, 0x4b, 0x6a, 0x04, 0x9c, 0x2d, 0x99, 0x63, 0x24,
+    0xee, 0x5d, 0x82, 0xa9, 0x0c, 0xa3, 0x36, 0x0c,
+  ]),
+);
 
-export const WITNESS_COSIGNATURE = new Uint8Array([
-  0x98, 0x2d, 0xfe, 0x23, 0xaf, 0x26, 0x4d, 0xe2, 0x76, 0xe3, 0x55, 0x67, 0xe1,
-  0x62, 0x13, 0x9a, 0xd2, 0xcd, 0xba, 0xc9, 0x47, 0xb9, 0xff, 0x6d, 0xc7, 0x0a,
-  0xee, 0x02, 0xc3, 0xaa, 0x79, 0x8b, 0x3a, 0x46, 0xdc, 0x7d, 0x28, 0x90, 0x67,
-  0x10, 0x7e, 0x52, 0xd1, 0x0d, 0xa0, 0x57, 0x12, 0x92, 0x38, 0xe0, 0x7a, 0xfc,
-  0x33, 0xa1, 0x61, 0x0a, 0x28, 0x33, 0xf5, 0xfc, 0xc3, 0x33, 0x44, 0x01,
-]) as Signature;
+export const WITNESS_COSIGNATURE = new Signature(
+  new Uint8Array([
+    0x98, 0x2d, 0xfe, 0x23, 0xaf, 0x26, 0x4d, 0xe2, 0x76, 0xe3, 0x55, 0x67,
+    0xe1, 0x62, 0x13, 0x9a, 0xd2, 0xcd, 0xba, 0xc9, 0x47, 0xb9, 0xff, 0x6d,
+    0xc7, 0x0a, 0xee, 0x02, 0xc3, 0xaa, 0x79, 0x8b, 0x3a, 0x46, 0xdc, 0x7d,
+    0x28, 0x90, 0x67, 0x10, 0x7e, 0x52, 0xd1, 0x0d, 0xa0, 0x57, 0x12, 0x92,
+    0x38, 0xe0, 0x7a, 0xfc, 0x33, 0xa1, 0x61, 0x0a, 0x28, 0x33, 0xf5, 0xfc,
+    0xc3, 0x33, 0x44, 0x01,
+  ]),
+);
 
 export const WITNESS_TIMESTAMP = 1748943073;
 
 describe("crypto", () => {
   it("imports a valid Ed25519 raw public key", async () => {
     const key = await importKey(VALID_PUBLIC_KEY);
-    expect(key.type).toBe("public");
+
+    expect(key.key.type).toBe("public");
+    expect(key.key.algorithm.name).toBe("Ed25519");
+    expect(key.key.extractable).toBe(true);
+    expect(key.key.usages).toEqual(["verify"]);
   });
 
   it("throws on invalid raw public key length", async () => {
-    const badKey = VALID_PUBLIC_KEY.slice(0, 30);
-    await expect(importKey(badKey as RawPublicKey)).rejects.toThrow();
+    const badKey = VALID_PUBLIC_KEY.bytes.slice(0, 30);
+    await expect(importKey(new RawPublicKey(badKey))).rejects.toThrow();
   });
 
   it("returns true for a valid signature", async () => {
@@ -118,29 +140,27 @@ describe("crypto", () => {
 
   it("throws if signature is too short", async () => {
     const key = await importKey(VALID_PUBLIC_KEY);
-    const shortSig = new Uint8Array(63);
     await expect(() =>
-      verifySignature(key, shortSig as Signature, VALID_MESSAGE),
+      verifySignature(key, new Signature(new Uint8Array(63)), VALID_MESSAGE),
     ).rejects.toThrow(/64 bytes/);
   });
 
   it("throws if signature is too long", async () => {
     const key = await importKey(VALID_PUBLIC_KEY);
-    const longSig = new Uint8Array(65);
     await expect(() =>
-      verifySignature(key, longSig as Signature, VALID_MESSAGE),
+      verifySignature(key, new Signature(new Uint8Array(65)), VALID_MESSAGE),
     ).rejects.toThrow(/64 bytes/);
   });
 
   it("returns false for all-zero public key", async () => {
-    const zeroKey = await importKey(new Uint8Array(32) as RawPublicKey);
+    const zeroKey = await importKey(new RawPublicKey(new Uint8Array(32)));
     const ok = await verifySignature(zeroKey, VALID_SIGNATURE, VALID_MESSAGE);
     expect(ok).toBe(false);
   });
 
   it("returns false for all-0xFF public key", async () => {
     const ffKey = await importKey(
-      new Uint8Array(32).fill(0xff) as RawPublicKey,
+      new RawPublicKey(new Uint8Array(32).fill(0xff)),
     );
     const ok = await verifySignature(ffKey, VALID_SIGNATURE, VALID_MESSAGE);
     expect(ok).toBe(false);
@@ -148,22 +168,21 @@ describe("crypto", () => {
 
   it("returns a valid base64 SHA-256 hash", async () => {
     const key = await importKey(VALID_PUBLIC_KEY);
-    const hash = Uint8ArrayToBase64(await hashKey(key));
-
+    const hash = Uint8ArrayToBase64((await hashKey(key)).bytes);
     expect(hash).toMatch(/^[a-zA-Z0-9+/]+={0,2}$/);
     expect(hash.length).toBeGreaterThan(40);
   });
 
   it("returns a consistent hash for the same key", async () => {
     const key = await importKey(VALID_PUBLIC_KEY);
-    const h1 = Uint8ArrayToBase64(await hashKey(key));
-    const h2 = Uint8ArrayToBase64(await hashKey(key));
+    const h1 = Uint8ArrayToBase64((await hashKey(key)).bytes);
+    const h2 = Uint8ArrayToBase64((await hashKey(key)).bytes);
     expect(h1).toBe(h2);
   });
 
   it("returns the expected base64 SHA-256 hash for known key", async () => {
     const key = await importKey(VALID_PUBLIC_KEY);
-    const hash = Uint8ArrayToBase64(await hashKey(key));
+    const hash = Uint8ArrayToBase64((await hashKey(key)).bytes);
     expect(hash).toBe(EXPECTED_BASE64_HASH);
   });
 
@@ -193,34 +212,12 @@ describe("crypto", () => {
     const publicKey = await importKey(LOG_PUBKEY);
     const logKeyHash = await hashKey(publicKey);
 
-    const corruptedRootHash = new Uint8Array(TREEHEAD_ROOT_HASH);
-    corruptedRootHash[corruptedRootHash.length - 1] ^= 0xff;
+    const corrupted = TREEHEAD_ROOT_HASH.bytes.slice();
+    corrupted[corrupted.length - 1] ^= 0xff;
 
     const treeHead: TreeHead = {
       Size: 899,
-      RootHash: corruptedRootHash as Hash,
-    };
-
-    const signedTreeHead: SignedTreeHead = {
-      TreeHead: treeHead,
-      Signature: TREEHEAD_SIGNATURE,
-    };
-
-    const result = await verifySignedTreeHead(
-      signedTreeHead,
-      publicKey,
-      logKeyHash,
-    );
-    expect(result).toBe(false);
-  });
-
-  it("fails to verify if size is tampered", async () => {
-    const publicKey = await importKey(LOG_PUBKEY);
-    const logKeyHash = await hashKey(publicKey);
-
-    const treeHead: TreeHead = {
-      Size: 900,
-      RootHash: TREEHEAD_ROOT_HASH,
+      RootHash: new Hash(corrupted),
     };
 
     const signedTreeHead: SignedTreeHead = {
@@ -240,17 +237,12 @@ describe("crypto", () => {
     const publicKey = await importKey(LOG_PUBKEY);
     const logKeyHash = await hashKey(publicKey);
 
-    const corruptedSignature = new Uint8Array(TREEHEAD_SIGNATURE);
-    corruptedSignature[corruptedSignature.length - 1] ^= 0xff;
-
-    const treeHead: TreeHead = {
-      Size: 899,
-      RootHash: TREEHEAD_ROOT_HASH,
-    };
+    const corrupted = TREEHEAD_SIGNATURE.bytes.slice();
+    corrupted[corrupted.length - 1] ^= 0xff;
 
     const signedTreeHead: SignedTreeHead = {
-      TreeHead: treeHead,
-      Signature: corruptedSignature as Signature,
+      TreeHead: { Size: 899, RootHash: TREEHEAD_ROOT_HASH },
+      Signature: new Signature(corrupted),
     };
 
     const result = await verifySignedTreeHead(
@@ -261,46 +253,15 @@ describe("crypto", () => {
     expect(result).toBe(false);
   });
 
-  it("fails to verify if log public key is tampered", async () => {
-    const corruptedPubKey = new Uint8Array(LOG_PUBKEY);
-    corruptedPubKey[corruptedPubKey.length - 1] ^= 0xff;
+  it("fails to verify if public key is tampered", async () => {
+    const corrupted = LOG_PUBKEY.bytes.slice();
+    corrupted[corrupted.length - 1] ^= 0xff;
 
-    const publicKey = await importKey(corruptedPubKey as RawPublicKey);
+    const publicKey = await importKey(new RawPublicKey(corrupted));
     const logKeyHash = await hashKey(publicKey);
 
-    const treeHead: TreeHead = {
-      Size: 899,
-      RootHash: TREEHEAD_ROOT_HASH,
-    };
-
     const signedTreeHead: SignedTreeHead = {
-      TreeHead: treeHead,
-      Signature: TREEHEAD_SIGNATURE,
-    };
-
-    const result = await verifySignedTreeHead(
-      signedTreeHead,
-      publicKey,
-      logKeyHash,
-    );
-    expect(result).toBe(false);
-  });
-
-  it("fails to verify if log public key does not match key hash", async () => {
-    const corruptedPubKey = new Uint8Array(LOG_PUBKEY);
-    corruptedPubKey[corruptedPubKey.length - 1] ^= 0xff;
-
-    const publicKey = await importKey(LOG_PUBKEY);
-    const publicKeyCorrupted = await importKey(corruptedPubKey as RawPublicKey);
-    const logKeyHash = await hashKey(publicKeyCorrupted);
-
-    const treeHead: TreeHead = {
-      Size: 899,
-      RootHash: TREEHEAD_ROOT_HASH,
-    };
-
-    const signedTreeHead: SignedTreeHead = {
-      TreeHead: treeHead,
+      TreeHead: { Size: 899, RootHash: TREEHEAD_ROOT_HASH },
       Signature: TREEHEAD_SIGNATURE,
     };
 
@@ -336,7 +297,7 @@ describe("crypto", () => {
     expect(result).toBe(true);
   });
 
-  it("fails to verify a cosignature with tampered timestanp", async () => {
+  it("fails to verify a cosignature with tampered timestamp", async () => {
     const witnessPublicKey = await importKey(WITNESS_PUBKEY);
     const logPublicKey = await importKey(LOG_PUBKEY);
     const logKeyHash = await hashKey(logPublicKey);
@@ -360,12 +321,14 @@ describe("crypto", () => {
     expect(result).toBe(false);
   });
 
-  it("fails when tree size is one and the leaf does not match the root", async () => {
+  it("fails when tree size is one and leaf mismatch", async () => {
     const proof = await SigsumProof.fromAscii(PROOF);
-    const checksum: Hash = await hashMessage(
-      await hashMessage(new Uint8Array([0x1, 0x2])),
+
+    const checksum = await hashMessage(
+      (await hashMessage(new Uint8Array([0x1, 0x2]))).bytes,
     );
     const leafHash = await proof.leaf.toLeaf(checksum).hashLeaf();
+
     await expect(() =>
       verifyInclusionProof(
         leafHash,
@@ -392,7 +355,7 @@ describe("constantTimeBufferEqual", () => {
 
   it("returns false for same length but different content", () => {
     const a = new Uint8Array([5, 6, 7]);
-    const b = new Uint8Array([5, 9, 7]); // difference at index 1
+    const b = new Uint8Array([5, 9, 7]);
     expect(constantTimeBufferEqual(a, b)).toBe(false);
   });
 });

--- a/src/tests/policyCompiler.test.ts
+++ b/src/tests/policyCompiler.test.ts
@@ -108,4 +108,26 @@ describe("policyCompiler", () => {
       /Policy quorum too complex/i,
     );
   });
+
+  it("covers add-and-sort branch when member bytecode size increases", async () => {
+    const w = Array.from({ length: 70 }, (_, i) => {
+      const hex = i.toString(16).padStart(64, "0");
+      return `witness W${i} ${hex}`;
+    }).join("\n");
+
+    const members = Array.from({ length: 70 }, (_, i) => `W${i}`).join(" ");
+
+    const policy = `
+      log ${"11".repeat(32)}
+      ${w}
+      group g any ${members}
+      quorum g
+    `;
+
+    const compiled = await compilePolicy(policy);
+
+    expect(compiled).toBeInstanceOf(Uint8Array);
+    expect(compiled.length).toBeGreaterThan(4 + 32 * (1 + 70));
+    expect(compiled[3]).toBeGreaterThan(0);
+  });
 });

--- a/src/tests/proof.test.ts
+++ b/src/tests/proof.test.ts
@@ -30,9 +30,9 @@ node_hash=b6be547daa4f6b3d42628bb14020e9b2d73a4ee8cf3c4e0a3b88793916926f27
     expect(proof.inclusion.LeafIndex).toBe(898);
     expect(proof.inclusion.Path).toHaveLength(4);
     expect(
-      Uint8ArrayToHex(proof.treeHead.SignedTreeHead.TreeHead.RootHash),
+      Uint8ArrayToHex(proof.treeHead.SignedTreeHead.TreeHead.RootHash.bytes),
     ).toBe("22596c882dcdfbfaba693cb69b225c81a8a980e84b3ad5fc1fcd6a256ebdc235");
-    expect(Object.keys(proof.treeHead.Cosignatures)).toHaveLength(5);
+    expect(proof.treeHead.Cosignatures.size).toBe(5);
   });
 
   it("parses a full version 2 proof with cosignatures and inclusion proof", async () => {
@@ -61,9 +61,9 @@ node_hash=b6be547daa4f6b3d42628bb14020e9b2d73a4ee8cf3c4e0a3b88793916926f27
     expect(proof.inclusion.LeafIndex).toBe(898);
     expect(proof.inclusion.Path).toHaveLength(4);
     expect(
-      Uint8ArrayToHex(proof.treeHead.SignedTreeHead.TreeHead.RootHash),
+      Uint8ArrayToHex(proof.treeHead.SignedTreeHead.TreeHead.RootHash.bytes),
     ).toBe("22596c882dcdfbfaba693cb69b225c81a8a980e84b3ad5fc1fcd6a256ebdc235");
-    expect(Object.keys(proof.treeHead.Cosignatures)).toHaveLength(5);
+    expect(proof.treeHead.Cosignatures.size).toBe(5);
   });
 
   it("fails when version line is missing", async () => {


### PR DESCRIPTION
Sadly TS 5.9 updated the typing system and branded types became broken. I have migrated them to dedicated classes instead. This approach feels less native and more code heavy, but it's hopefully more future-proof. Added the compiled policy verifier, and now the verify tests automatically uses both the standard verifier and the compiled one.

The logic for the compiled verifier should be reviewed because it is an AI-assisted port of the C code.